### PR TITLE
fix: handle None paragraph style in DOCX extraction

### DIFF
--- a/ingestion/extraction.py
+++ b/ingestion/extraction.py
@@ -145,7 +145,7 @@ def _extract_docx(content: bytes) -> ExtractedText:
         if not text:
             continue
 
-        style_name = (para.style.name or "").lower()
+        style_name = ((para.style.name if para.style else "") or "").lower()
         if "heading" in style_name:
             # Extract heading level from style name (e.g., "Heading 2")
             level_match = re.search(r"(\d+)", style_name)


### PR DESCRIPTION
## Summary

- Guard against `para.style` being `None` in `_extract_docx()`, which caused ingestion to crash on certain DOCX files

## Root cause

`para.style` can be `None` for paragraphs in DOCX files created by non-Microsoft editors or converted from other formats. The existing code only guarded against `para.style.name` being `None`, not `para.style` itself.

## Fix

```python
# Before
style_name = (para.style.name or "").lower()

# After
style_name = ((para.style.name if para.style else "") or "").lower()
```

Fixes #6